### PR TITLE
feat: add favorites functionality for clubs and teams

### DIFF
--- a/app/components/app/header.vue
+++ b/app/components/app/header.vue
@@ -14,6 +14,11 @@ const links = [
     icon: 'i-lucide-search',
     to: '/tournament',
   },
+  {
+    label: t('favorites'),
+    icon: 'i-lucide-star',
+    to: '/favorites',
+  },
 ]
 </script>
 

--- a/app/components/club/search.vue
+++ b/app/components/club/search.vue
@@ -1,9 +1,11 @@
 <script lang="ts" setup>
 import type { TableColumn, TableRow } from '@nuxt/ui'
-import { UAvatar } from '#components'
+import { UAvatar, UButton } from '#components'
 import { h } from 'vue'
+import { useFavorites } from '~/composables/useFavorites'
 
 const { t } = useI18n()
+const { isFavoriteClub, toggleFavoriteClub } = useFavorites()
 
 interface Club {
   id: number
@@ -47,6 +49,29 @@ const columns: TableColumn<Club>[] = [{
     const org = row.getValue('organization') as Club['organization'] || { name: '', logo: '' }
     return h(UAvatar, { src: org.logo, alt: org.name })
   },
+}, {
+  id: 'favorite',
+  header: '',
+  cell: ({ row }) => {
+    const club = row.original
+    const isFav = isFavoriteClub(club.id.toString())
+    return h(UButton, {
+      icon: isFav ? 'i-heroicons-star-solid' : 'i-heroicons-star',
+      color: isFav ? 'primary' : 'gray',
+      variant: 'ghost',
+      title: isFav ? t('removeFromFavorites') : t('addToFavorites'),
+      onClick: (e: Event) => {
+        e.stopPropagation()
+        toggleFavoriteClub({
+          id: club.id.toString(),
+          name: club.name,
+          logo: club.logo,
+          acronym: club.acronym,
+          organizationName: club.organization?.name,
+        })
+      },
+    })
+  },
 }]
 
 const columnVisibility = ref({
@@ -89,8 +114,18 @@ function onRowSelected(e: Event, row: TableRow<Club>) {
         <div class="flex items-center gap-4">
           <UAvatar :src="club.logo" :alt="club.acronym" size="lg" class="shrink-0 bg-white" />
           <div class="flex flex-col flex-1 min-w-0">
-            <div class="font-bold text-lg truncate">
-              {{ club.name }}
+            <div class="flex justify-between items-center">
+              <div class="font-bold text-lg truncate">
+                {{ club.name }}
+              </div>
+              <UButton
+                :icon="isFavoriteClub(club.id.toString()) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
+                :color="isFavoriteClub(club.id.toString()) ? 'primary' : 'gray'"
+                variant="ghost"
+                class="ml-2"
+                :title="isFavoriteClub(club.id.toString()) ? t('removeFromFavorites') : t('addToFavorites')"
+                @click.stop="toggleFavoriteClub({ id: club.id.toString(), name: club.name, logo: club.logo, acronym: club.acronym, organizationName: club.organization?.name })"
+              />
             </div>
             <div class="text-sm text-gray-500 flex items-center gap-2 mt-1">
               <UBadge v-if="club.acronym" :label="club.acronym" size="xs" variant="subtle" />

--- a/app/components/team/table.vue
+++ b/app/components/team/table.vue
@@ -1,6 +1,9 @@
 <script lang="ts" setup>
 import type { TableColumn, TableRow } from '@nuxt/ui'
 import type { Team } from '../../../types'
+import { UButton } from '#components'
+import { h } from 'vue'
+import { useFavorites } from '~/composables/useFavorites'
 
 const props = defineProps({
   clubId: {
@@ -10,6 +13,7 @@ const props = defineProps({
 })
 const { clubId } = props
 const { t } = useI18n()
+const { isFavoriteTeam, toggleFavoriteTeam } = useFavorites()
 
 const columns: TableColumn<Team>[] = [{
   accessorKey: 'id',
@@ -23,6 +27,28 @@ const columns: TableColumn<Team>[] = [{
 }, {
   accessorKey: 'defaultTournament.acronym',
   header: t('acronym'),
+}, {
+  id: 'favorite',
+  header: '',
+  cell: ({ row }) => {
+    const team = row.original
+    const isFav = isFavoriteTeam(team.id.toString())
+    return h(UButton, {
+      icon: isFav ? 'i-heroicons-star-solid' : 'i-heroicons-star',
+      color: isFav ? 'primary' : 'gray',
+      variant: 'ghost',
+      title: isFav ? t('removeFromFavorites') : t('addToFavorites'),
+      onClick: (e: Event) => {
+        e.stopPropagation()
+        toggleFavoriteTeam({
+          id: team.id.toString(),
+          name: team.name,
+          logo: team.logo,
+          tournamentAcronym: team.defaultTournament?.acronym,
+        })
+      },
+    })
+  },
 }]
 
 const columnVisibility = ref({
@@ -51,8 +77,18 @@ function onRowSelected(e: Event, row: TableRow<Team>) {
       </div>
       <UCard v-for="team in teams" v-else :key="team.id" class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors" @click="navigateTo(`/team/details/${team.id}`)">
         <div class="flex flex-col gap-1">
-          <div class="font-bold text-lg text-primary-600 dark:text-primary-400">
-            {{ team.name }}
+          <div class="flex justify-between items-start">
+            <div class="font-bold text-lg text-primary-600 dark:text-primary-400">
+              {{ team.name }}
+            </div>
+            <UButton
+              :icon="isFavoriteTeam(team.id.toString()) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
+              :color="isFavoriteTeam(team.id.toString()) ? 'primary' : 'gray'"
+              variant="ghost"
+              class="ml-2"
+              :title="isFavoriteTeam(team.id.toString()) ? t('removeFromFavorites') : t('addToFavorites')"
+              @click.stop="toggleFavoriteTeam({ id: team.id.toString(), name: team.name, logo: team.logo, tournamentAcronym: team.defaultTournament?.acronym })"
+            />
           </div>
           <div class="text-sm text-gray-600 dark:text-gray-300 flex items-center gap-2">
             <UIcon name="i-heroicons-trophy" class="w-4 h-4" />

--- a/app/composables/useFavorites.ts
+++ b/app/composables/useFavorites.ts
@@ -1,0 +1,51 @@
+import { useLocalStorage } from '@vueuse/core'
+
+export interface FavoriteClub {
+  id: string
+  name: string
+  logo?: string
+  acronym?: string
+  organizationName?: string
+}
+
+export interface FavoriteTeam {
+  id: string
+  name: string
+  logo?: string
+  tournamentAcronym?: string
+}
+
+export function useFavorites() {
+  const favoriteClubs = useLocalStorage<FavoriteClub[]>('favorites-clubs', [])
+  const favoriteTeams = useLocalStorage<FavoriteTeam[]>('favorites-teams', [])
+
+  const isFavoriteClub = (id: string) => favoriteClubs.value.some(c => c.id === id)
+  const isFavoriteTeam = (id: string) => favoriteTeams.value.some(t => t.id === id)
+
+  const toggleFavoriteClub = (club: FavoriteClub) => {
+    if (isFavoriteClub(club.id)) {
+      favoriteClubs.value = favoriteClubs.value.filter(c => c.id !== club.id)
+    }
+    else {
+      favoriteClubs.value.push(club)
+    }
+  }
+
+  const toggleFavoriteTeam = (team: FavoriteTeam) => {
+    if (isFavoriteTeam(team.id)) {
+      favoriteTeams.value = favoriteTeams.value.filter(t => t.id !== team.id)
+    }
+    else {
+      favoriteTeams.value.push(team)
+    }
+  }
+
+  return {
+    favoriteClubs,
+    favoriteTeams,
+    isFavoriteClub,
+    isFavoriteTeam,
+    toggleFavoriteClub,
+    toggleFavoriteTeam,
+  }
+}

--- a/app/pages/club/details/[id]/index.vue
+++ b/app/pages/club/details/[id]/index.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { useFavorites } from '~/composables/useFavorites'
+
 const route = useRoute()
 const clubId = route.params.id as string
 const club = ref({
@@ -15,6 +17,8 @@ const club = ref({
 
 const { t } = useI18n()
 const requestURL = useRequestURL()
+
+const { isFavoriteClub, toggleFavoriteClub } = useFavorites()
 
 const { data } = await useAsyncData(
   `club/${clubId}`,
@@ -65,7 +69,18 @@ useHead({
 <template>
   <div>
     <UPage>
-      <UPageHeader :headline="t('clubDetails')" :title="club.name" />
+      <UPageHeader :headline="t('clubDetails')" :title="club.name">
+        <template #links>
+          <UButton
+            :icon="isFavoriteClub(clubId) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
+            :color="isFavoriteClub(clubId) ? 'primary' : 'gray'"
+            variant="ghost"
+            size="xl"
+            :title="isFavoriteClub(clubId) ? t('removeFromFavorites') : t('addToFavorites')"
+            @click="toggleFavoriteClub({ id: clubId, name: club.name, logo: club.logo, acronym: club.acronym, organizationName: club.organization?.name })"
+          />
+        </template>
+      </UPageHeader>
       <UPageBody>
         <ClubHeader :club="club" />
         <br> <br>

--- a/app/pages/favorites.vue
+++ b/app/pages/favorites.vue
@@ -1,0 +1,72 @@
+<script lang="ts" setup>
+import { useFavorites } from '~/composables/useFavorites'
+
+const { t } = useI18n()
+const { favoriteClubs, favoriteTeams } = useFavorites()
+</script>
+
+<template>
+  <UPage>
+    <UPageHeader :title="t('myFavorites')" />
+
+    <UPageBody>
+      <div v-if="favoriteClubs.length === 0 && favoriteTeams.length === 0" class="text-center py-12 text-gray-500">
+        <UIcon name="i-lucide-star" class="w-12 h-12 mx-auto mb-4 text-gray-400" />
+        <p class="text-lg">
+          {{ t('noFavoritesYet') }}
+        </p>
+      </div>
+
+      <div v-else class="space-y-12">
+        <section v-if="favoriteTeams.length > 0">
+          <h2 class="text-2xl font-bold mb-6 flex items-center gap-2">
+            <UIcon name="i-lucide-users" class="w-6 h-6" />
+            {{ t('favoriteTeams') }}
+          </h2>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <UCard v-for="team in favoriteTeams" :key="team.id" class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors" @click="navigateTo(`/team/details/${team.id}`)">
+              <div class="flex items-center gap-4">
+                <UAvatar :src="team.logo" :alt="team.name" size="lg" class="shrink-0 bg-white" />
+                <div class="flex flex-col flex-1 min-w-0">
+                  <div class="font-bold text-lg truncate">
+                    {{ team.name }}
+                  </div>
+                  <div v-if="team.tournamentAcronym" class="text-sm text-gray-500 mt-1">
+                    <UBadge :label="team.tournamentAcronym" size="xs" variant="subtle" />
+                  </div>
+                </div>
+              </div>
+            </UCard>
+          </div>
+        </section>
+
+        <section v-if="favoriteClubs.length > 0">
+          <h2 class="text-2xl font-bold mb-6 flex items-center gap-2">
+            <UIcon name="i-lucide-shield" class="w-6 h-6" />
+            {{ t('favoriteClubs') }}
+          </h2>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <UCard v-for="club in favoriteClubs" :key="club.id" class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors" @click="navigateTo(`/club/details/${club.id}`)">
+              <div class="flex items-center gap-4">
+                <UAvatar :src="club.logo" :alt="club.acronym" size="lg" class="shrink-0 bg-white" />
+                <div class="flex flex-col flex-1 min-w-0">
+                  <div class="font-bold text-lg truncate">
+                    {{ club.name }}
+                  </div>
+                  <div class="text-sm text-gray-500 flex items-center gap-2 mt-1">
+                    <UBadge v-if="club.acronym" :label="club.acronym" size="xs" variant="subtle" />
+                    <span v-if="club.organizationName" class="truncate max-w-[100px] ml-auto">
+                      {{ club.organizationName }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </UCard>
+          </div>
+        </section>
+      </div>
+    </UPageBody>
+  </UPage>
+</template>

--- a/app/pages/team/details/[...id].vue
+++ b/app/pages/team/details/[...id].vue
@@ -1,9 +1,17 @@
 <script lang="ts" setup>
+import { useFavorites } from '~/composables/useFavorites'
+
 const route = useRoute()
 const router = useRouter()
 const team = ref()
 const { t } = useI18n()
 const requestURL = useRequestURL()
+
+const { isFavoriteTeam, toggleFavoriteTeam } = useFavorites()
+const teamId = computed(() => {
+  const idParam = route.params.id
+  return Array.isArray(idParam) ? idParam[0] : idParam
+})
 
 const items = [{
   slot: 'standing',
@@ -118,7 +126,18 @@ const { data: games, pending: gamesPending } = await useAsyncData(
 <template>
   <div>
     <UPage>
-      <UPageHeader :title="team.name" :headline="team.defaultTournament.name" />
+      <UPageHeader :title="team.name" :headline="team.defaultTournament.name">
+        <template #links>
+          <UButton
+            :icon="isFavoriteTeam(teamId) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
+            :color="isFavoriteTeam(teamId) ? 'primary' : 'gray'"
+            variant="ghost"
+            size="xl"
+            :title="isFavoriteTeam(teamId) ? t('removeFromFavorites') : t('addToFavorites')"
+            @click="toggleFavoriteTeam({ id: team.id.toString(), name: team.name, logo: team.logo, tournamentAcronym: team.defaultTournament?.acronym })"
+          />
+        </template>
+      </UPageHeader>
       <UPageBody>
         <UTabs v-model="activeTab" :items="items" value-key="slot" class="w-full" variant="link">
           <template #default="{ item }">

--- a/config/pwa.ts
+++ b/config/pwa.ts
@@ -14,6 +14,14 @@ export const pwa: ModuleOptions = {
     categories: ['games', 'sports', 'handball'],
     id: '/',
     orientation: 'portrait',
+    shortcuts: [
+      {
+        name: 'Meine Favoriten',
+        short_name: 'Favoriten',
+        description: 'Direkt zu deinen favorisierten Teams und Vereinen',
+        url: '/favorites',
+      },
+    ],
     screenshots: [
       {
         src: '../public/screenshots/desktop_standing.png',

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -89,5 +89,13 @@
   "forcedRelegation": "Zwangsabsteiger",
   "promotionBlocked": "Kein Aufstieg möglich",
   "withdrawn": "Zurückgezogen",
-  "organizations": "Verbände/ Bezirke"
+  "organizations": "Verbände/ Bezirke",
+  "favorites": "Favoriten",
+  "myFavorites": "Meine Favoriten",
+  "noFavoritesYet": "Noch keine Favoriten gespeichert.",
+  "addToFavorites": "Zu Favoriten hinzufügen",
+  "removeFromFavorites": "Aus Favoriten entfernen",
+  "favoriteClubs": "Favorisierte Vereine",
+  "favoriteTeams": "Favorisierte Mannschaften",
+  "noData": "Keine Daten verfügbar"
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -89,5 +89,13 @@
   "forcedRelegation": "Forced Relegation",
   "promotionBlocked": "Promotion blocked",
   "withdrawn": "Withdrawn",
-  "organizations": "Organizations"
+  "organizations": "Organizations",
+  "favorites": "Favorites",
+  "myFavorites": "My Favorites",
+  "noFavoritesYet": "No favorites saved yet.",
+  "addToFavorites": "Add to favorites",
+  "removeFromFavorites": "Remove from favorites",
+  "favoriteClubs": "Favorite Clubs",
+  "favoriteTeams": "Favorite Teams",
+  "noData": "No data available"
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,6 +21,7 @@ const modulesList = [
   '@nuxt/ui',
   '@nuxtjs/i18n',
   '@nuxt/image',
+  '@vueuse/nuxt',
 ]
 
 if (isTest) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@nuxthub/core": "^0.10.7",
     "@nuxtjs/i18n": "^10.3.0",
     "@vite-pwa/nuxt": "1.1.1",
+    "@vueuse/core": "^14.3.0",
+    "@vueuse/nuxt": "^14.3.0",
     "better-sqlite3": "^12.9.0",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       '@vite-pwa/nuxt':
         specifier: 1.1.1
         version: 1.1.1(@vite-pwa/assets-generator@1.0.2)(magicast@0.5.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0)(workbox-window@7.4.0)
+      '@vueuse/core':
+        specifier: ^14.3.0
+        version: 14.3.0(vue@3.5.33(typescript@5.9.3))
+      '@vueuse/nuxt':
+        specifier: ^14.3.0
+        version: 14.3.0(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@libsql/client@0.17.3)(better-sqlite3@12.9.0)))(drizzle-orm@0.45.2(@libsql/client@0.17.3)(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -2163,6 +2169,10 @@ packages:
 
   '@nuxt/kit@4.4.2':
     resolution: {integrity: sha512-5+IPRNX2CjkBhuWUwz0hBuLqiaJPRoKzQ+SvcdrQDbAyE+VDeFt74VpSFr5/R0ujrK4b+XnSHUJWdS72w6hsog==}
+    engines: {node: '>=18.12.0'}
+
+  '@nuxt/kit@4.4.4':
+    resolution: {integrity: sha512-oy4fAeMkyz7gelnalDQLPm8QZRN+c5c/Eh/M6oFgPx86jnA8m6xeOlONpJN2dk0GhcJwJYuN/kmzBffZ93WXPQ==}
     engines: {node: '>=18.12.0'}
 
   '@nuxt/nitro-server@4.4.2':
@@ -4490,6 +4500,11 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
+  '@vueuse/core@14.3.0':
+    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+    peerDependencies:
+      vue: ^3.5.0
+
   '@vueuse/integrations@14.2.1':
     resolution: {integrity: sha512-2LIUpBi/67PoXJGqSDQUF0pgQWpNHh7beiA+KG2AbybcNm+pTGWT6oPGlBgUoDWmYwfeQqM/uzOHqcILpKL7nA==}
     peerDependencies:
@@ -4538,11 +4553,25 @@ packages:
   '@vueuse/metadata@14.2.1':
     resolution: {integrity: sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==}
 
+  '@vueuse/metadata@14.3.0':
+    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
+
+  '@vueuse/nuxt@14.3.0':
+    resolution: {integrity: sha512-Uxaz/DsNa3i7vHTSjZin5R17R5pt+MtpAifsfqhV1qiBZti1wYv+/S3xysCMHuuiWyLIbbignKxIsgG9ul5kEA==}
+    peerDependencies:
+      nuxt: ^3.0.0 || ^4.0.0-0
+      vue: ^3.5.0
+
   '@vueuse/shared@10.11.1':
     resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
 
   '@vueuse/shared@14.2.1':
     resolution: {integrity: sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/shared@14.3.0':
+    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -7452,6 +7481,9 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -8534,6 +8566,9 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
@@ -11453,6 +11488,31 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxt/kit@4.4.4(magicast@0.5.2)':
+    dependencies:
+      c12: 3.3.4(magicast@0.5.2)
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.8
+      ignore: 7.0.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      mlly: 1.8.2
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+      scule: 1.3.0
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ufo: 1.6.4
+      unctx: 2.5.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
   '@nuxt/nitro-server@4.4.2(9949137c7c536d0432a5584ed3cb10bd)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
@@ -11614,7 +11674,7 @@ snapshots:
       '@tiptap/suggestion': 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
       '@tiptap/vue-3': 3.22.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)(vue@3.5.33(typescript@5.9.3))
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@5.9.3))
-      '@vueuse/core': 14.2.1(vue@3.5.33(typescript@5.9.3))
+      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@5.9.3))
       '@vueuse/integrations': 14.2.1(change-case@5.4.4)(fuse.js@7.3.0)(vue@3.5.33(typescript@5.9.3))
       '@vueuse/shared': 14.2.1(vue@3.5.33(typescript@5.9.3))
       colortranslator: 5.0.0
@@ -11632,7 +11692,7 @@ snapshots:
       knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.2
-      motion-v: 2.2.1(@vueuse/core@14.2.1(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
+      motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       ohash: 2.0.11
       pathe: 2.0.3
       reka-ui: 2.9.6(vue@3.5.33(typescript@5.9.3))
@@ -11644,7 +11704,7 @@ snapshots:
       typescript: 5.9.3
       ufo: 1.6.3
       unplugin: 3.0.0
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(@vueuse/core@14.2.1(vue@3.5.33(typescript@5.9.3)))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.33(typescript@5.9.3)))
       unplugin-vue-components: 32.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(vue@3.5.33(typescript@5.9.3))
       vaul-vue: 0.4.1(reka-ui@2.9.6(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       vue-component-type-helpers: 3.2.7
@@ -13652,6 +13712,13 @@ snapshots:
       '@vueuse/shared': 14.2.1(vue@3.5.33(typescript@5.9.3))
       vue: 3.5.33(typescript@5.9.3)
 
+  '@vueuse/core@14.3.0(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.3.0
+      '@vueuse/shared': 14.3.0(vue@3.5.33(typescript@5.9.3))
+      vue: 3.5.33(typescript@5.9.3)
+
   '@vueuse/integrations@14.2.1(change-case@5.4.4)(fuse.js@7.3.0)(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       '@vueuse/core': 14.2.1(vue@3.5.33(typescript@5.9.3))
@@ -13665,6 +13732,19 @@ snapshots:
 
   '@vueuse/metadata@14.2.1': {}
 
+  '@vueuse/metadata@14.3.0': {}
+
+  '@vueuse/nuxt@14.3.0(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@libsql/client@0.17.3)(better-sqlite3@12.9.0)))(drizzle-orm@0.45.2(@libsql/client@0.17.3)(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@5.9.3))
+      '@vueuse/metadata': 14.3.0
+      local-pkg: 1.1.2
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@vue/compiler-sfc@3.5.33)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@libsql/client@0.17.3)(better-sqlite3@12.9.0)))(drizzle-orm@0.45.2(@libsql/client@0.17.3)(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      vue: 3.5.33(typescript@5.9.3)
+    transitivePeerDependencies:
+      - magicast
+
   '@vueuse/shared@10.11.1(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       vue-demi: 0.14.10(vue@3.5.33(typescript@5.9.3))
@@ -13673,6 +13753,10 @@ snapshots:
       - vue
 
   '@vueuse/shared@14.2.1(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.33(typescript@5.9.3)
+
+  '@vueuse/shared@14.3.0(vue@3.5.33(typescript@5.9.3))':
     dependencies:
       vue: 3.5.33(typescript@5.9.3)
 
@@ -16655,9 +16739,9 @@ snapshots:
 
   motion-utils@12.36.0: {}
 
-  motion-v@2.2.1(@vueuse/core@14.2.1(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)):
+  motion-v@2.2.1(@vueuse/core@14.3.0(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3)):
     dependencies:
-      '@vueuse/core': 14.2.1(vue@3.5.33(typescript@5.9.3))
+      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@5.9.3))
       framer-motion: 12.38.0
       hey-listen: 1.0.8
       motion-dom: 12.38.0
@@ -17353,6 +17437,12 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
   pluralize@8.0.0: {}
 
   pnpm-workspace-yaml@1.6.0:
@@ -17826,7 +17916,7 @@ snapshots:
       '@internationalized/date': 3.12.1
       '@internationalized/number': 3.6.6
       '@tanstack/vue-virtual': 3.13.24(vue@3.5.33(typescript@5.9.3))
-      '@vueuse/core': 14.2.1(vue@3.5.33(typescript@5.9.3))
+      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@5.9.3))
       '@vueuse/shared': 14.2.1(vue@3.5.33(typescript@5.9.3))
       aria-hidden: 1.2.6
       defu: 6.1.7
@@ -18724,6 +18814,8 @@ snapshots:
 
   ufo@1.6.3: {}
 
+  ufo@1.6.4: {}
+
   ultrahtml@1.6.0: {}
 
   unbox-primitive@1.1.0:
@@ -18877,7 +18969,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(@vueuse/core@14.2.1(vue@3.5.33(typescript@5.9.3))):
+  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.33(typescript@5.9.3))):
     dependencies:
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -18887,7 +18979,7 @@ snapshots:
       unplugin-utils: 0.3.1
     optionalDependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@vueuse/core': 14.2.1(vue@3.5.33(typescript@5.9.3))
+      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@5.9.3))
 
   unplugin-utils@0.3.1:
     dependencies:


### PR DESCRIPTION
This submission implements the favorites feature, allowing users to star clubs and teams to have them saved in their browser's local storage without needing an account. The feature includes a new Favorites page, shortcuts in the PWA configuration, new i18n translations, and star actions embedded in the listing and detail pages.

---
*PR created automatically by Jules for task [819407383084670584](https://jules.google.com/task/819407383084670584) started by @miggi92*