### PR TITLE
🔒 [security] Implement input validation for 'clubName' in searchClub API

### DIFF
--- a/server/api/dhb/searchClub.ts
+++ b/server/api/dhb/searchClub.ts
@@ -1,4 +1,9 @@
+import { z } from 'zod'
 import { getClubsUrl, normalizeImageUrl } from '../../../server/utils/dhbUtils'
+
+const querySchema = z.object({
+  clubName: z.string().min(1, 'Expected a clubname but got none'),
+})
 
 defineRouteMeta({
   openAPI: {
@@ -50,17 +55,15 @@ defineRouteMeta({
  * @throws {Error}
  */
 export default defineEventHandler(async (event) => {
-  const query = getQuery(event)
+  const query = await getValidatedQuery(event, data => querySchema.parse(data))
 
-  if (!query.clubName) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'Expected a clubname but got none',
-    })
-  }
-  const clubs = await $fetch(`${getClubsUrl()}/search?query=${query.clubName}`)
+  const clubs: any = await $fetch(`${getClubsUrl()}/search`, {
+    query: {
+      query: query.clubName,
+    },
+  })
 
-  clubs.data.forEach((club) => {
+  clubs.data.forEach((club: any) => {
     if (club.logo) {
       club.logo = normalizeImageUrl(club.logo)
     }

--- a/tests/server/api/dhb/searchClub.spec.ts
+++ b/tests/server/api/dhb/searchClub.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createError } from 'h3'
+
+// Mocking h3 and other dependencies
+vi.mock('h3', async () => {
+  const actual = await vi.importActual('h3')
+  return {
+    ...actual as any,
+    getValidatedQuery: vi.fn(),
+    defineEventHandler: (handler: any) => handler,
+  }
+})
+
+vi.mock('../../../../server/utils/dhbUtils', () => ({
+  getClubsUrl: () => 'https://api.handball.net/clubs',
+  normalizeImageUrl: (url: string) => url,
+}))
+
+global.$fetch = vi.fn() as any
+
+import handler from '../../../../server/api/dhb/searchClub'
+import { getValidatedQuery } from 'h3'
+
+describe('searchClub API', () => {
+  it('should return club data when valid clubName is provided', async () => {
+    const mockQuery = { clubName: 'THW Kiel' }
+    const mockClubsData = {
+      data: [
+        {
+          logo: 'logo-url',
+          organization: { logo: 'org-logo-url' },
+        },
+      ],
+    }
+
+    vi.mocked(getValidatedQuery).mockResolvedValue(mockQuery)
+    vi.mocked($fetch).mockResolvedValue(mockClubsData)
+
+    const result = await (handler as any)({})
+
+    expect(result).toEqual(mockClubsData.data)
+    expect($fetch).toHaveBeenCalledWith('https://api.handball.net/clubs/search', {
+      query: { query: 'THW Kiel' },
+    })
+  })
+
+  it('should throw error when clubName is missing', async () => {
+    vi.mocked(getValidatedQuery).mockImplementation(async (_event, validator) => {
+      // Simulate zod validation failure
+      try {
+          validator({})
+      } catch (e: any) {
+          throw createError({
+              statusCode: 400,
+              statusMessage: e.message,
+          })
+      }
+    })
+
+    await expect((handler as any)({})).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability in the `searchClub` API endpoint where the `clubName` query parameter was used without robust validation.

⚠️ **Risk:** Missing input validation and string interpolation in the outgoing API request could potentially lead to parameter injection or malformed requests if `clubName` contained special characters.

🛡️ **Solution:**
1.  Implemented a Zod schema to validate that `clubName` is a non-empty string.
2.  Used Nuxt/H3's `getValidatedQuery` to enforce the schema on the incoming request.
3.  Refactored the `$fetch` call to pass the search query via the `query` option instead of template string interpolation. This ensures proper URL encoding and prevents query parameter injection.
4.  Added a new Vitest suite in `tests/server/api/dhb/searchClub.spec.ts` to verify the fix.

---
*PR created automatically by Jules for task [14006131948861791145](https://jules.google.com/task/14006131948861791145) started by @miggi92*