### PR TITLE
Show player photos in lineups, adopt Nuxt UI semantic color tokens

### DIFF
--- a/app/components/app/originInfo.vue
+++ b/app/components/app/originInfo.vue
@@ -12,7 +12,7 @@ const { t } = useI18n()
     <br>
     <ULink
       to="https://handball.net" active-class="text-primary"
-      inactive-class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+      inactive-class="text-muted hover:text-toned"
     >
       https://handball.net
     </ULink>

--- a/app/components/club/search.vue
+++ b/app/components/club/search.vue
@@ -53,7 +53,7 @@ const columns: TableColumn<Club>[] = [{
     const isFav = isFavoriteClub(club.id.toString())
     return h(UButton, {
       icon: isFav ? 'i-heroicons-star-solid' : 'i-heroicons-star',
-      color: isFav ? 'primary' : 'gray',
+      color: isFav ? 'primary' : 'neutral',
       variant: 'ghost',
       title: isFav ? t('removeFromFavorites') : t('addToFavorites'),
       onClick: (e: Event) => {
@@ -105,7 +105,7 @@ function onRowSelected(e: Event, row: TableRow<Club>) {
       <div v-if="loading" class="space-y-4">
         <USkeleton v-for="i in 3" :key="i" class="h-24 w-full" />
       </div>
-      <UCard v-for="club in clubs" v-else :key="club.id" class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors" @click="navigateTo(`/club/details/${club.id}`)">
+      <UCard v-for="club in clubs" v-else :key="club.id" class="p-4 cursor-pointer hover:bg-elevated transition-colors" @click="navigateTo(`/club/details/${club.id}`)">
         <div class="flex items-center gap-4">
           <UAvatar :src="club.logo" :alt="club.name" size="lg" class="shrink-0 bg-white" />
           <div class="flex flex-col flex-1 min-w-0">
@@ -115,14 +115,14 @@ function onRowSelected(e: Event, row: TableRow<Club>) {
               </div>
               <UButton
                 :icon="isFavoriteClub(club.id.toString()) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
-                :color="isFavoriteClub(club.id.toString()) ? 'primary' : 'gray'"
+                :color="isFavoriteClub(club.id.toString()) ? 'primary' : 'neutral'"
                 variant="ghost"
                 class="ml-2"
                 :title="isFavoriteClub(club.id.toString()) ? t('removeFromFavorites') : t('addToFavorites')"
                 @click.stop="toggleFavoriteClub({ id: club.id.toString(), name: club.name, logo: club.logo, organizationName: club.organization?.name })"
               />
             </div>
-            <div v-if="club.organization" class="text-sm text-gray-500 flex items-center gap-2 mt-1">
+            <div v-if="club.organization" class="text-sm text-muted flex items-center gap-2 mt-1">
               <div class="flex items-center gap-1 ml-auto">
                 <UAvatar :src="club.organization.logo" :alt="club.organization.name" size="2xs" class="bg-white" />
                 <span class="truncate max-w-[100px]">{{ club.organization.name }}</span>
@@ -132,7 +132,7 @@ function onRowSelected(e: Event, row: TableRow<Club>) {
         </div>
       </UCard>
 
-      <div v-if="clubs && clubs.length === 0 && !loading && state.clubName" class="text-center py-8 text-gray-500">
+      <div v-if="clubs && clubs.length === 0 && !loading && state.clubName" class="text-center py-8 text-muted">
         {{ t('noData') }}
       </div>
     </div>

--- a/app/components/shared/lineupTable.vue
+++ b/app/components/shared/lineupTable.vue
@@ -6,6 +6,7 @@ interface Player {
   id: string
   firstname: string
   lastname: string
+  photoUrl?: string
   gamesPlayed?: number
   goals?: number
   goalsPerGame?: number
@@ -42,6 +43,7 @@ const { t } = useI18n()
 const UButton = resolveComponent('UButton')
 const UDropdownMenu = resolveComponent('UDropdownMenu')
 const UBadge = resolveComponent('UBadge')
+const UAvatar = resolveComponent('UAvatar')
 
 // Helper function to check if a column should be shown
 function shouldShowColumn(fieldName: string) {
@@ -69,7 +71,13 @@ const columns = computed<TableColumn<any>[]>(() => {
     {
       accessorKey: 'name',
       header: ({ column }) => getHeader(column, t('name')),
-      cell: ({ row }) => `${row.original.firstname} ${row.original.lastname}`,
+      cell: ({ row }) => {
+        const name = `${row.original.firstname} ${row.original.lastname}`
+        return h('div', { class: 'flex items-center gap-2' }, [
+          h(UAvatar, { src: row.original.photoUrl, alt: name, size: 'xs' }),
+          h('span', name),
+        ])
+      },
       footer: ({ column }) => {
         const rowCount = column.getFacetedRowModel().rows.length
         return h('div', { class: 'text-center font-medium' }, `${rowCount} ${t('players')}`)
@@ -240,8 +248,8 @@ function getHeader(column: Column<any>, label: string) {
 
 <template>
   <div>
-    <div v-if="showSearch" class="flex px-3 py-3.5 border-b border-gray-200 dark:border-gray-700">
-      <UInput v-model="q" :placeholder="t('filter')" />
+    <div v-if="showSearch" class="flex px-3 py-3.5 border-b border-default">
+      <UInput v-model="q" :placeholder="t('filter')" icon="i-lucide-search" class="w-full" />
     </div>
 
     <!-- Mobile View (Cards) -->
@@ -251,63 +259,66 @@ function getHeader(column: Column<any>, label: string) {
       </div>
       <UCard v-for="player in filteredRows" v-else :key="player.id" class="p-4">
         <div class="flex flex-col gap-2">
-          <div class="font-bold text-lg border-b border-gray-100 dark:border-gray-800 pb-2 mb-1 flex justify-between items-center">
-            <span>{{ player.firstname }} {{ player.lastname }}</span>
+          <div class="border-b border-default pb-2 mb-1 flex justify-between items-center gap-2">
+            <div class="flex items-center gap-2 min-w-0">
+              <UAvatar :src="player.photoUrl" :alt="`${player.firstname} ${player.lastname}`" size="md" />
+              <span class="font-bold text-lg truncate">{{ player.firstname }} {{ player.lastname }}</span>
+            </div>
             <div v-if="showTeams && player.teams" class="flex gap-1 flex-wrap justify-end">
               <UBadge v-for="team in player.teams" :key="team.id" :label="team.acronym || team.name" size="sm" />
             </div>
-            <div v-if="showClub && player.team" class="flex justify-end">
+            <div v-if="showClub && player.team" class="flex justify-end shrink-0">
               <UBadge :label="player.team.name" size="sm" variant="outline" :avatar="{ src: player.team.logo || '', alt: player.team.name }" />
             </div>
           </div>
 
           <div class="grid grid-cols-2 gap-y-2 text-sm">
-            <div class="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+            <div class="flex items-center gap-1 text-muted">
               <UIcon name="i-mdi-whistle" class="w-4 h-4" />
               <span>{{ t('gamesPlayed') }}:</span>
-              <strong class="text-gray-900 dark:text-white ml-auto">{{ player.gamesPlayed || 0 }}</strong>
+              <strong class="text-highlighted ml-auto">{{ player.gamesPlayed || 0 }}</strong>
             </div>
 
-            <div class="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+            <div class="flex items-center gap-1 text-muted">
               <UIcon name="i-mdi-soccer" class="w-4 h-4" />
               <span>{{ t('goals') }}:</span>
-              <strong class="text-gray-900 dark:text-white ml-auto">{{ player.goals || 0 }}</strong>
+              <strong class="text-highlighted ml-auto">{{ player.goals || 0 }}</strong>
             </div>
 
-            <div class="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+            <div class="flex items-center gap-1 text-muted">
               <UIcon name="i-mdi-chart-line" class="w-4 h-4" />
               <span>Ø:</span>
-              <strong class="text-gray-900 dark:text-white ml-auto">{{ player.gamesPlayed && player.goals ? (player.goals / player.gamesPlayed).toFixed(2) : '0.00' }}</strong>
+              <strong class="text-highlighted ml-auto">{{ player.gamesPlayed && player.goals ? (player.goals / player.gamesPlayed).toFixed(2) : '0.00' }}</strong>
             </div>
 
-            <div v-if="player.yellowCards" class="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+            <div v-if="player.yellowCards" class="flex items-center gap-1 text-muted">
               <div class="w-3 h-4 bg-yellow-400 rounded-sm" />
               <span>{{ t('yellowCards') }}:</span>
-              <strong class="text-gray-900 dark:text-white ml-auto">{{ player.yellowCards }}</strong>
+              <strong class="text-highlighted ml-auto">{{ player.yellowCards }}</strong>
             </div>
 
-            <div v-if="player.redCards" class="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+            <div v-if="player.redCards" class="flex items-center gap-1 text-muted">
               <div class="w-3 h-4 bg-red-500 rounded-sm" />
               <span>{{ t('redCards') }}:</span>
-              <strong class="text-gray-900 dark:text-white ml-auto">{{ player.redCards }}</strong>
+              <strong class="text-highlighted ml-auto">{{ player.redCards }}</strong>
             </div>
 
-            <div v-if="player.blueCards" class="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+            <div v-if="player.blueCards" class="flex items-center gap-1 text-muted">
               <div class="w-3 h-4 bg-blue-500 rounded-sm" />
               <span>{{ t('blueCards') }}:</span>
-              <strong class="text-gray-900 dark:text-white ml-auto">{{ player.blueCards }}</strong>
+              <strong class="text-highlighted ml-auto">{{ player.blueCards }}</strong>
             </div>
 
-            <div v-if="player.penalties" class="flex items-center gap-1 text-gray-500 dark:text-gray-400 col-span-2">
+            <div v-if="player.penalties" class="flex items-center gap-1 text-muted col-span-2">
               <UIcon name="i-mdi-hand-back-left" class="w-4 h-4" />
               <span>{{ t('penalties') }}:</span>
-              <strong class="text-gray-900 dark:text-white ml-auto">{{ player.penalties }}</strong>
+              <strong class="text-highlighted ml-auto">{{ player.penalties }}</strong>
             </div>
           </div>
         </div>
       </UCard>
 
-      <div v-if="filteredRows.length === 0 && !loading" class="text-center py-8 text-gray-500">
+      <div v-if="filteredRows.length === 0 && !loading" class="text-center py-8 text-muted">
         {{ t('noData') }}
       </div>
     </div>

--- a/app/components/shared/standingTable.vue
+++ b/app/components/shared/standingTable.vue
@@ -56,7 +56,7 @@ const meta: TableMeta<Team> = {
       <div v-if="props.loading" class="space-y-4">
         <USkeleton v-for="i in 5" :key="i" class="h-24 w-full" />
       </div>
-      <UCard v-for="(row, index) in props.data" v-else :key="row.team?.id || index" class="p-2" :class="[row.team?.id === props.teamId ? 'ring ring-primary-500/50 bg-primary-50/50 dark:bg-primary-900/10' : '']">
+      <UCard v-for="(row, index) in props.data" v-else :key="row.team?.id || index" class="p-2" :class="[row.team?.id === props.teamId ? 'ring ring-primary/50 bg-primary/5' : '']">
         <div class="flex items-center gap-4">
           <div class="font-bold text-lg w-6 text-center">
             {{ row.rank }}
@@ -66,8 +66,8 @@ const meta: TableMeta<Team> = {
             <div class="font-semibold text-base truncate">
               {{ row.team?.name }}
             </div>
-            <div class="text-sm text-gray-500 dark:text-gray-400 mt-1 flex flex-wrap gap-x-3 gap-y-1">
-              <span>{{ t('points') }}: <strong class="text-gray-900 dark:text-white">{{ row.points }}</strong></span>
+            <div class="text-sm text-muted mt-1 flex flex-wrap gap-x-3 gap-y-1">
+              <span>{{ t('points') }}: <strong class="text-highlighted">{{ row.points }}</strong></span>
               <span>{{ t('games') }}: {{ row.games }}</span>
               <span>{{ t('goals') }}: {{ row.goals }}:{{ row.goalsAgainst }}</span>
             </div>

--- a/app/components/team/games.vue
+++ b/app/components/team/games.vue
@@ -40,18 +40,14 @@ const conditionalColumns = [
     cell: ({ row }) => {
       if (!row.original.pdfUrl)
         return ''
-      return h('a', {
-        'href': row.original.pdfUrl,
+      return h(resolveComponent('UButton'), {
+        'to': row.original.pdfUrl,
         'target': '_blank',
-        'rel': 'noopener noreferrer',
-        'class': 'inline-flex items-center justify-center w-8 h-8 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors',
+        'icon': 'i-heroicons-document-text',
+        'color': 'neutral',
+        'variant': 'ghost',
         'aria-label': 'Open PDF',
-      }, [
-        h(resolveComponent('UIcon'), {
-          name: 'i-heroicons-document-text',
-          class: 'w-5 h-5',
-        }),
-      ])
+      })
     },
   },
 ]
@@ -97,27 +93,27 @@ const columns = computed<TableColumn<any>[]>(() => {
         <template #header>
           <div class="flex justify-between items-start">
             {{ game.homeTeam?.name }} vs {{ game.awayTeam?.name }}
-            <div v-if="game.result" class="text-sm font-medium text-green-600">
+            <div v-if="game.result" class="text-sm font-medium text-success">
               {{ game.result }}
             </div>
           </div>
         </template>
 
         <div class="space-y-2">
-          <div class="text-sm text-gray-500">
+          <div class="text-sm text-muted">
             {{ game.startsAt }}
           </div>
-          <div v-if="game.field?.name" class="text-sm text-gray-500">
+          <div v-if="game.field?.name" class="text-sm text-muted">
             📍 {{ game.field.name }}
           </div>
         </div>
 
         <template #footer>
-          <div v-if="game.remarks" class="text-sm text-gray-600">
+          <div v-if="game.remarks" class="text-sm text-toned">
             <UIcon name="i-heroicons-document" /> {{ game.remarks }}
           </div>
           <div class="grid grid-cols-2 gap-4 items-center">
-            <div v-if="game.referee" class="text-sm text-gray-600">
+            <div v-if="game.referee" class="text-sm text-toned">
               <UIcon name="i-heroicons-users" /> {{ game.referee }}
             </div>
             <div v-if="game.pdfUrl" class="pt-2 justify-self-end">

--- a/app/components/team/prognose.vue
+++ b/app/components/team/prognose.vue
@@ -199,7 +199,7 @@ const state = reactive({
 
               <span class="truncate">{{ item.label }}</span>
 
-              <span class="absolute -right-4 w-2 h-2 rounded-full bg-primary-500 dark:bg-primary-400" />
+              <span class="absolute -right-4 w-2 h-2 rounded-full bg-primary" />
             </div>
           </template>
           <template #home>
@@ -214,7 +214,7 @@ const state = reactive({
             <UFormField :label="t('homeQuota')">
               <UInput v-model="state.homeQuota" disabled>
                 <template #trailing>
-                  <span class="text-gray-500 dark:text-gray-400 text-xs">%</span>
+                  <span class="text-muted text-xs">%</span>
                 </template>
               </UInput>
             </UFormField>
@@ -239,7 +239,7 @@ const state = reactive({
             <UFormField :label="t('awayQuota')">
               <UInput v-model="state.awayQuota" disabled>
                 <template #trailing>
-                  <span class="text-gray-500 dark:text-gray-400 text-xs">%</span>
+                  <span class="text-muted text-xs">%</span>
                 </template>
               </UInput>
             </UFormField>

--- a/app/components/team/table.vue
+++ b/app/components/team/table.vue
@@ -32,7 +32,7 @@ const columns: TableColumn<Team>[] = [{
     const isFav = isFavoriteTeam(team.id.toString())
     return h(UButton, {
       icon: isFav ? 'i-heroicons-star-solid' : 'i-heroicons-star',
-      color: isFav ? 'primary' : 'gray',
+      color: isFav ? 'primary' : 'neutral',
       variant: 'ghost',
       title: isFav ? t('removeFromFavorites') : t('addToFavorites'),
       onClick: (e: Event) => {
@@ -71,22 +71,22 @@ function onRowSelected(e: Event, row: TableRow<Team>) {
       <div v-if="teamsPending" class="space-y-4">
         <USkeleton v-for="i in 3" :key="i" class="h-24 w-full" />
       </div>
-      <UCard v-for="team in teams" v-else :key="team.id" class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors" @click="navigateTo(`/team/details/${team.id}`)">
+      <UCard v-for="team in teams" v-else :key="team.id" class="p-4 cursor-pointer hover:bg-elevated transition-colors" @click="navigateTo(`/team/details/${team.id}`)">
         <div class="flex flex-col gap-1">
           <div class="flex justify-between items-start">
-            <div class="font-bold text-lg text-primary-600 dark:text-primary-400">
+            <div class="font-bold text-lg text-primary">
               {{ team.name }}
             </div>
             <UButton
               :icon="isFavoriteTeam(team.id.toString()) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
-              :color="isFavoriteTeam(team.id.toString()) ? 'primary' : 'gray'"
+              :color="isFavoriteTeam(team.id.toString()) ? 'primary' : 'neutral'"
               variant="ghost"
               class="ml-2"
               :title="isFavoriteTeam(team.id.toString()) ? t('removeFromFavorites') : t('addToFavorites')"
               @click.stop="toggleFavoriteTeam({ id: team.id.toString(), name: team.name, logo: team.logo })"
             />
           </div>
-          <div v-if="team.league?.name" class="text-sm text-gray-600 dark:text-gray-300 flex items-center gap-2">
+          <div v-if="team.league?.name" class="text-sm text-muted flex items-center gap-2">
             <UIcon name="i-heroicons-trophy" class="w-4 h-4" />
             <span>{{ team.league.name }}</span>
           </div>

--- a/app/components/tournament/search.vue
+++ b/app/components/tournament/search.vue
@@ -78,14 +78,14 @@ function onRowSelected(e: Event, row: TableRow<any>) {
       <div v-if="loading" class="space-y-4">
         <USkeleton v-for="i in 3" :key="i" class="h-24 w-full" />
       </div>
-      <UCard v-for="tournament in clubs" v-else :key="tournament.id" class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors" @click="navigateTo(`/tournament/${tournament.id}`)">
+      <UCard v-for="tournament in clubs" v-else :key="tournament.id" class="p-4 cursor-pointer hover:bg-elevated transition-colors" @click="navigateTo(`/tournament/${tournament.id}`)">
         <div class="flex items-center gap-4">
           <UAvatar :src="tournament.logo" :alt="tournament.acronym" size="lg" class="shrink-0 bg-white" />
           <div class="flex flex-col flex-1 min-w-0">
             <div class="font-bold text-lg truncate">
               {{ tournament.name }}
             </div>
-            <div class="text-sm text-gray-500 flex items-center gap-2 mt-1">
+            <div class="text-sm text-muted flex items-center gap-2 mt-1">
               <UBadge v-if="tournament.acronym" :label="tournament.acronym" size="xs" variant="subtle" />
               <div v-if="tournament.organization" class="flex items-center gap-1 ml-auto">
                 <UAvatar :src="tournament.organization.logo" :alt="tournament.organization.name" size="2xs" class="bg-white" />
@@ -96,7 +96,7 @@ function onRowSelected(e: Event, row: TableRow<any>) {
         </div>
       </UCard>
 
-      <div v-if="clubs && clubs.length === 0 && !loading && state.tournament" class="text-center py-8 text-gray-500">
+      <div v-if="clubs && clubs.length === 0 && !loading && state.tournament" class="text-center py-8 text-muted">
         {{ t('noData') }}
       </div>
     </div>

--- a/app/pages/club/details/[id]/index.vue
+++ b/app/pages/club/details/[id]/index.vue
@@ -73,7 +73,7 @@ useHead({
         <template #links>
           <UButton
             :icon="isFavoriteClub(clubId) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
-            :color="isFavoriteClub(clubId) ? 'primary' : 'gray'"
+            :color="isFavoriteClub(clubId) ? 'primary' : 'neutral'"
             variant="ghost"
             size="xl"
             :title="isFavoriteClub(clubId) ? t('removeFromFavorites') : t('addToFavorites')"

--- a/app/pages/favorites.vue
+++ b/app/pages/favorites.vue
@@ -10,8 +10,8 @@ const { favoriteClubs, favoriteTeams } = useFavorites()
     <UPageHeader :title="t('myFavorites')" />
 
     <UPageBody>
-      <div v-if="favoriteClubs.length === 0 && favoriteTeams.length === 0" class="text-center py-12 text-gray-500">
-        <UIcon name="i-lucide-star" class="w-12 h-12 mx-auto mb-4 text-gray-400" />
+      <div v-if="favoriteClubs.length === 0 && favoriteTeams.length === 0" class="text-center py-12 text-muted">
+        <UIcon name="i-lucide-star" class="w-12 h-12 mx-auto mb-4 text-dimmed" />
         <p class="text-lg">
           {{ t('noFavoritesYet') }}
         </p>
@@ -25,14 +25,14 @@ const { favoriteClubs, favoriteTeams } = useFavorites()
           </h2>
 
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <UCard v-for="team in favoriteTeams" :key="team.id" class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors" @click="navigateTo(`/team/details/${team.id}`)">
+            <UCard v-for="team in favoriteTeams" :key="team.id" class="p-4 cursor-pointer hover:bg-elevated transition-colors" @click="navigateTo(`/team/details/${team.id}`)">
               <div class="flex items-center gap-4">
                 <UAvatar :src="team.logo" :alt="team.name" size="lg" class="shrink-0 bg-white" />
                 <div class="flex flex-col flex-1 min-w-0">
                   <div class="font-bold text-lg truncate">
                     {{ team.name }}
                   </div>
-                  <div v-if="team.tournamentAcronym" class="text-sm text-gray-500 mt-1">
+                  <div v-if="team.tournamentAcronym" class="text-sm text-muted mt-1">
                     <UBadge :label="team.tournamentAcronym" size="xs" variant="subtle" />
                   </div>
                 </div>
@@ -48,14 +48,14 @@ const { favoriteClubs, favoriteTeams } = useFavorites()
           </h2>
 
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <UCard v-for="club in favoriteClubs" :key="club.id" class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors" @click="navigateTo(`/club/details/${club.id}`)">
+            <UCard v-for="club in favoriteClubs" :key="club.id" class="p-4 cursor-pointer hover:bg-elevated transition-colors" @click="navigateTo(`/club/details/${club.id}`)">
               <div class="flex items-center gap-4">
                 <UAvatar :src="club.logo" :alt="club.acronym" size="lg" class="shrink-0 bg-white" />
                 <div class="flex flex-col flex-1 min-w-0">
                   <div class="font-bold text-lg truncate">
                     {{ club.name }}
                   </div>
-                  <div class="text-sm text-gray-500 flex items-center gap-2 mt-1">
+                  <div class="text-sm text-muted flex items-center gap-2 mt-1">
                     <UBadge v-if="club.acronym" :label="club.acronym" size="xs" variant="subtle" />
                     <span v-if="club.organizationName" class="truncate max-w-[100px] ml-auto">
                       {{ club.organizationName }}

--- a/app/pages/organizations/[...id].vue
+++ b/app/pages/organizations/[...id].vue
@@ -31,7 +31,7 @@ const {
   loadedLeagueCount,
 } = useOrganizationLeagues(organizationId, selectedLeagueType)
 
-const leagueTypeButtonLabel = computed(() => selectedLeagueType.value === 'm' ? 'Zu den Damen' : 'Zu den Herren')
+const leagueTypeButtonLabel = computed(() => selectedLeagueType.value === 'm' ? t('toWomen') : t('toMen'))
 
 function toggleLeagueType() {
   selectedLeagueType.value = selectedLeagueType.value === 'm' ? 'f' : 'm'
@@ -107,7 +107,7 @@ function isForcedRelegation(league: LeagueResult, row: TableRow): boolean {
     <div v-if="isLoadingLeagues && totalLeagueCount" class="mb-6 space-y-2">
       <UProgress :model-value="loadedLeagueCount" :max="totalLeagueCount" size="sm" color="primary" status />
       <p class="text-sm text-muted">
-        {{ loadedLeagueCount }} / {{ totalLeagueCount }} Ligen geladen ({{ loadingProgressPercent }}%)
+        {{ t('leaguesLoaded', { loaded: loadedLeagueCount, total: totalLeagueCount, percent: loadingProgressPercent }) }}
       </p>
     </div>
 
@@ -125,7 +125,7 @@ function isForcedRelegation(league: LeagueResult, row: TableRow): boolean {
       </h2>
 
       <div v-if="league.promoted.length" class="space-y-2">
-        <h3 class="text-base font-semibold text-warning-600">
+        <h3 class="text-base font-semibold text-warning">
           {{ t('promoted') }} ({{ league.promoted.length }} {{ t('teams') }})
         </h3>
         <LazyUPageGrid>
@@ -137,7 +137,7 @@ function isForcedRelegation(league: LeagueResult, row: TableRow): boolean {
       </div>
 
       <div v-if="league.promotionPlayoff.length" class="space-y-2">
-        <h3 class="text-base font-semibold text-warning-600">
+        <h3 class="text-base font-semibold text-warning">
           {{ t('promotionPlayoff') }} ({{ league.promotionPlayoffSpots }} <span
             v-if="league.promotionPlayoffSpots !== 1"
           >{{ t('ranks') }}</span><span v-else>{{ t('rank')
@@ -152,7 +152,7 @@ function isForcedRelegation(league: LeagueResult, row: TableRow): boolean {
       </div>
 
       <div v-if="league.relegated.length || league.forcedRelegations.length" class="space-y-2">
-        <h3 class="text-base font-semibold text-warning-600">
+        <h3 class="text-base font-semibold text-warning">
           {{ t('relegated') }} ({{ league.relegated.length + league.forcedRelegations.length }} {{ t('teams')
           }})
         </h3>
@@ -166,7 +166,7 @@ function isForcedRelegation(league: LeagueResult, row: TableRow): boolean {
       </div>
 
       <div v-if="league.relegationPlayoff.length" class="space-y-2">
-        <h3 class="text-base font-semibold text-warning-600">
+        <h3 class="text-base font-semibold text-warning">
           {{ t('relegationPlayoff') }} ({{ league.relegationPlayoffSpots }} <span
             v-if="league.relegationPlayoffSpots !== 1"
           >{{ t('ranks') }}</span><span v-else>{{ t('rank')

--- a/app/pages/team/details/[...id].vue
+++ b/app/pages/team/details/[...id].vue
@@ -129,7 +129,7 @@ const { data: games, pending: gamesPending } = await useAsyncData(
         <template #links>
           <UButton
             :icon="isFavoriteTeam(teamId) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
-            :color="isFavoriteTeam(teamId) ? 'primary' : 'gray'"
+            :color="isFavoriteTeam(teamId) ? 'primary' : 'neutral'"
             variant="ghost"
             size="xl"
             :title="isFavoriteTeam(teamId) ? t('removeFromFavorites') : t('addToFavorites')"
@@ -145,7 +145,7 @@ const { data: games, pending: gamesPending } = await useAsyncData(
 
               <span class="truncate">{{ item.label }}</span>
 
-              <span class="absolute -right-4 w-2 h-2 rounded-full bg-primary-500 dark:bg-primary-400" />
+              <span class="absolute -right-4 w-2 h-2 rounded-full bg-primary" />
             </div>
           </template>
           <template #standing>

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -97,5 +97,8 @@
   "removeFromFavorites": "Aus Favoriten entfernen",
   "favoriteClubs": "Favorisierte Vereine",
   "favoriteTeams": "Favorisierte Mannschaften",
-  "noData": "Keine Daten verfügbar"
+  "noData": "Keine Daten verfügbar",
+  "toWomen": "Zu den Damen",
+  "toMen": "Zu den Herren",
+  "leaguesLoaded": "{loaded} / {total} Ligen geladen ({percent}%)"
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -97,5 +97,8 @@
   "removeFromFavorites": "Remove from favorites",
   "favoriteClubs": "Favorite Clubs",
   "favoriteTeams": "Favorite Teams",
-  "noData": "No data available"
+  "noData": "No data available",
+  "toWomen": "To women's",
+  "toMen": "To men's",
+  "leaguesLoaded": "{loaded} / {total} leagues loaded ({percent}%)"
 }

--- a/server/api/dhb/game/lineup.ts
+++ b/server/api/dhb/game/lineup.ts
@@ -49,6 +49,7 @@ export default defineEventHandler(async (event) => {
         id: player.id,
         firstname: player.first_name,
         lastname: player.last_name,
+        photoUrl: player.photo_url ?? undefined,
         position: '',
         number: 0,
         goals: 0,

--- a/server/api/dhb/team/standing.ts
+++ b/server/api/dhb/team/standing.ts
@@ -34,11 +34,5 @@ export default defineEventHandler(async (event) => {
   const standings = await dhbFetch<any[]>(getStandingsUrl(), { query: { phase_id: phase.id } })
   const currentRows = currentRoundOnly(standings.data)
 
-  const normalizedStandings = currentRows.map(mapStandingsRow)
-  const currentTeam = normalizedStandings.find(obj => String(obj.team.id) === String(teamId))
-  if (currentTeam) {
-    currentTeam.class = 'bg-primary-500 animate-pulse'
-  }
-
-  return normalizedStandings
+  return currentRows.map(mapStandingsRow)
 })

--- a/server/utils/dhbPlayerUtils.ts
+++ b/server/utils/dhbPlayerUtils.ts
@@ -16,6 +16,7 @@ export function mapPlayerStatsEntry(entry: any): Player {
     id: entry.player.id,
     firstname: entry.player.first_name,
     lastname: entry.player.last_name,
+    photoUrl: entry.player.photo_url ?? undefined,
     position: '',
     number: entry.dorsal ? Number(entry.dorsal) : 0,
     goals: stats.goals ?? 0,

--- a/types/player.d.ts
+++ b/types/player.d.ts
@@ -2,6 +2,7 @@ export interface Player {
   id: number
   firstname: string
   lastname: string
+  photoUrl?: string
   position: string
   number: number
   goals: number


### PR DESCRIPTION
## Summary

Follow-up to #287. The new handball.net API's `/stats/player-stats` and match-events endpoints return a `photo_url` per player - this wires it through and does a mobile-first Nuxt UI consistency pass across the app.

- **Player photos**: `Player.photoUrl` populated from the API, rendered via `UAvatar` in the lineup table (desktop + mobile) - falls back to initials when a player has no photo (confirmed via Nuxt UI docs that this is `UAvatar`'s built-in behavior).
- **Nuxt UI semantic color tokens**: replaced raw Tailwind gray/color-scale classes (`text-gray-500`, `bg-primary-500`, `text-warning-600`, ...) with Nuxt UI's semantic design tokens (`text-muted`, `text-highlighted`, `bg-elevated`, `bg-primary`, `text-warning`, ...) across the club/team/tournament search, standings, lineup, games, favorites, and origin-info views - verified against the official Nuxt UI docs via its MCP server. These adapt correctly to dark mode and to future theme-color changes, unlike hardcoded shades.
- **Real bug fix**: four favorite-star `UButton`s used `color="gray"`, which isn't a valid Nuxt UI 3/4 color (the neutral color is called `neutral`) - the "not favorited" state likely wasn't rendering as intended.
- Unified the desktop PDF-link cell in `team/games.vue` to use `UButton` instead of a raw `<a>`, matching the mobile view.
- Removed a dead `.class` field the standings API set but the frontend never read (it does its own highlight comparison via the `teamId` prop).
- Replaced two hardcoded German strings (the league type toggle button, the league-loading progress text) with i18n keys so they translate correctly in English too.

## Test plan

- [x] `pnpm lint` - clean
- [x] `pnpm test:run` - 5/5 files, 22/22 tests passing
- [x] `pnpm build` - production build + prerender succeeds
- [ ] Manual verification of player photos against live data (not possible from this sandbox - network to handball.net is blocked here)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HuhUfGqi8nC7ESQBsHFBin

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuhUfGqi8nC7ESQBsHFBin)_