### PR TITLE
Add mobile bottom nav, PWA install prompt, instant search, grouped teams, pull-to-refresh

### DIFF
--- a/app/components/app/bottomNav.vue
+++ b/app/components/app/bottomNav.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+const { t } = useI18n()
+const route = useRoute()
+
+const items = computed(() => [
+  { label: t('startPage'), icon: 'i-lucide-home', to: '/' },
+  { label: t('searchClub'), icon: 'i-lucide-search', to: '/club' },
+  { label: t('searchTournament'), icon: 'i-lucide-trophy', to: '/tournament' },
+  { label: t('favorites'), icon: 'i-lucide-star', to: '/favorites' },
+])
+
+function isActive(to: string) {
+  return to === '/' ? route.path === '/' : route.path.startsWith(to)
+}
+</script>
+
+<template>
+  <nav
+    class="md:hidden fixed inset-x-0 bottom-0 z-50 bg-default border-t border-default"
+    :style="{ paddingBottom: 'env(safe-area-inset-bottom)' }"
+  >
+    <div class="grid grid-cols-4">
+      <NuxtLink
+        v-for="item in items" :key="item.to" :to="item.to"
+        class="flex flex-col items-center justify-center gap-0.5 py-2 min-h-14 text-xs"
+        :class="isActive(item.to) ? 'text-primary' : 'text-muted'"
+      >
+        <UIcon :name="item.icon" class="w-5 h-5" />
+        <span class="truncate">{{ item.label }}</span>
+      </NuxtLink>
+    </div>
+  </nav>
+</template>

--- a/app/components/app/pullToRefresh.vue
+++ b/app/components/app/pullToRefresh.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const { pullDistance, isRefreshing, pullProgress } = usePullToRefresh(() => refreshNuxtData())
+</script>
+
+<template>
+  <div>
+    <div
+      class="flex items-center justify-center overflow-hidden transition-[height] ease-out"
+      :class="isRefreshing ? 'duration-200' : 'duration-0'"
+      :style="{ height: `${pullDistance}px` }"
+    >
+      <UIcon
+        :name="isRefreshing ? 'i-lucide-loader-circle' : 'i-lucide-arrow-down'"
+        class="w-5 h-5 text-muted transition-transform"
+        :class="{
+          'animate-spin': isRefreshing,
+          'rotate-180': !isRefreshing && pullProgress >= 1,
+        }"
+      />
+    </div>
+    <slot />
+  </div>
+</template>

--- a/app/components/app/pwaInstallPrompt.vue
+++ b/app/components/app/pwaInstallPrompt.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+const { t } = useI18n()
+const nuxtApp = useNuxtApp()
+const pwa = nuxtApp.$pwa
+
+async function install() {
+  await pwa?.install()
+}
+
+function dismiss() {
+  pwa?.cancelInstall()
+}
+</script>
+
+<template>
+  <div v-if="pwa?.showInstallPrompt" class="fixed inset-x-0 bottom-16 md:bottom-4 z-40 px-4 md:px-0 md:right-4 md:left-auto md:max-w-sm">
+    <UAlert
+      :title="t('installAppTitle')" :description="t('installAppDescription')" icon="i-lucide-download"
+      color="primary" variant="subtle" orientation="horizontal" close
+      :actions="[{ label: t('install'), onClick: install }]"
+      @update:open="dismiss"
+    />
+  </div>
+</template>

--- a/app/components/club/search.vue
+++ b/app/components/club/search.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { TableColumn, TableRow } from '@nuxt/ui'
+import { watchDebounced } from '@vueuse/core'
 import { h } from 'vue'
 import { UAvatar, UButton } from '#components'
 import { useFavorites } from '~/composables/useFavorites'
@@ -74,6 +75,10 @@ const columnVisibility = ref({
 })
 
 async function onSearch() {
+  if (!state.clubName || state.clubName.trim().length < 2) {
+    return
+  }
+
   loading.value = true
   const { data } = useAsyncData(`${state.clubName}`, () => $fetch('/api/dhb/searchClub', {
     query: { clubName: state.clubName },
@@ -81,6 +86,15 @@ async function onSearch() {
   clubs.value = data.value
   loading.value = false
 }
+
+watchDebounced(() => state.clubName, () => {
+  if (!state.clubName || state.clubName.trim().length < 2) {
+    clubs.value = []
+    return
+  }
+
+  onSearch()
+}, { debounce: 400 })
 
 function onRowSelected(e: Event, row: TableRow<Club>) {
   const clubId = row.getValue('id')

--- a/app/components/team/table.vue
+++ b/app/components/team/table.vue
@@ -58,6 +58,29 @@ const { data: teams, pending: teamsPending } = await useAsyncData(
   }),
 ) as unknown as { data: Team[], pending: boolean, error: any, refresh: () => object }
 
+const unknownLeagueLabel = computed(() => t('noLeague'))
+
+const sortedTeams = computed(() => {
+  return [...(teams.value || [])].sort((a, b) => {
+    const leagueA = a.league?.name ?? ''
+    const leagueB = b.league?.name ?? ''
+    return leagueA.localeCompare(leagueB) || a.name.localeCompare(b.name)
+  })
+})
+
+const groupedTeams = computed(() => {
+  const groups = new Map<string, Team[]>()
+
+  for (const team of sortedTeams.value) {
+    const key = team.league?.name || unknownLeagueLabel.value
+    const group = groups.get(key) ?? []
+    group.push(team)
+    groups.set(key, group)
+  }
+
+  return Array.from(groups.entries()).map(([league, teamsInLeague]) => ({ league, teams: teamsInLeague }))
+})
+
 function onRowSelected(e: Event, row: TableRow<Team>) {
   const teamId = row.getValue('id')
   navigateTo(`/team/details/${teamId}`)
@@ -66,38 +89,39 @@ function onRowSelected(e: Event, row: TableRow<Team>) {
 
 <template>
   <div>
-    <!-- Mobile View (Cards) -->
-    <div class="block md:hidden space-y-4">
+    <!-- Mobile View (Cards, grouped by league) -->
+    <div class="block md:hidden space-y-6">
       <div v-if="teamsPending" class="space-y-4">
         <USkeleton v-for="i in 3" :key="i" class="h-24 w-full" />
       </div>
-      <UCard v-for="team in teams" v-else :key="team.id" class="p-4 cursor-pointer hover:bg-elevated transition-colors" @click="navigateTo(`/team/details/${team.id}`)">
-        <div class="flex flex-col gap-1">
-          <div class="flex justify-between items-start">
-            <div class="font-bold text-lg text-primary">
-              {{ team.name }}
+      <div v-for="group in groupedTeams" v-else :key="group.league" class="space-y-3">
+        <h3 class="text-sm font-semibold text-muted uppercase tracking-wide">
+          {{ group.league }}
+        </h3>
+        <div class="space-y-3">
+          <UCard v-for="team in group.teams" :key="team.id" class="p-4 cursor-pointer hover:bg-elevated transition-colors" @click="navigateTo(`/team/details/${team.id}`)">
+            <div class="flex justify-between items-center">
+              <div class="font-bold text-lg text-primary">
+                {{ team.name }}
+              </div>
+              <UButton
+                :icon="isFavoriteTeam(team.id.toString()) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
+                :color="isFavoriteTeam(team.id.toString()) ? 'primary' : 'neutral'"
+                variant="ghost"
+                class="ml-2"
+                :title="isFavoriteTeam(team.id.toString()) ? t('removeFromFavorites') : t('addToFavorites')"
+                @click.stop="toggleFavoriteTeam({ id: team.id.toString(), name: team.name, logo: team.logo })"
+              />
             </div>
-            <UButton
-              :icon="isFavoriteTeam(team.id.toString()) ? 'i-heroicons-star-solid' : 'i-heroicons-star'"
-              :color="isFavoriteTeam(team.id.toString()) ? 'primary' : 'neutral'"
-              variant="ghost"
-              class="ml-2"
-              :title="isFavoriteTeam(team.id.toString()) ? t('removeFromFavorites') : t('addToFavorites')"
-              @click.stop="toggleFavoriteTeam({ id: team.id.toString(), name: team.name, logo: team.logo })"
-            />
-          </div>
-          <div v-if="team.league?.name" class="text-sm text-muted flex items-center gap-2">
-            <UIcon name="i-heroicons-trophy" class="w-4 h-4" />
-            <span>{{ team.league.name }}</span>
-          </div>
+          </UCard>
         </div>
-      </UCard>
+      </div>
     </div>
 
     <!-- Desktop View (Table) -->
     <div class="hidden md:block">
       <UTable
-        v-model:column-visibility="columnVisibility" :data="teams" :columns="columns" :loading="teamsPending"
+        v-model:column-visibility="columnVisibility" :data="sortedTeams" :columns="columns" :loading="teamsPending"
         @select="onRowSelected"
       />
     </div>

--- a/app/components/tournament/search.vue
+++ b/app/components/tournament/search.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { TableColumn, TableRow } from '@nuxt/ui'
+import { watchDebounced } from '@vueuse/core'
 import { h, resolveComponent } from 'vue'
 
 const { t } = useI18n()
@@ -47,6 +48,10 @@ const columnVisibility = ref({
 })
 
 async function onSearch() {
+  if (!state.tournament || state.tournament.trim().length < 2) {
+    return
+  }
+
   loading.value = true
   const { data } = useAsyncData(`${state.tournament}`, () => $fetch('/api/dhb/tournament/search', {
     query: { tournamentName: state.tournament },
@@ -54,6 +59,15 @@ async function onSearch() {
   clubs.value = data.value
   loading.value = false
 }
+
+watchDebounced(() => state.tournament, () => {
+  if (!state.tournament || state.tournament.trim().length < 2) {
+    clubs.value = []
+    return
+  }
+
+  onSearch()
+}, { debounce: 400 })
 
 function onRowSelected(e: Event, row: TableRow<any>) {
   const tournamentId = row.getValue('id')

--- a/app/composables/usePullToRefresh.ts
+++ b/app/composables/usePullToRefresh.ts
@@ -1,0 +1,95 @@
+const PULL_THRESHOLD = 70
+const MAX_PULL = 120
+const RESISTANCE = 0.5
+
+/**
+ * Native-app-style pull-to-refresh via touch events. Only activates when the
+ * page is scrolled to the top and the user drags down; releases past
+ * `PULL_THRESHOLD` trigger `onRefresh`.
+ */
+export function usePullToRefresh(onRefresh: () => Promise<unknown> | unknown) {
+  const pullDistance = ref(0)
+  const isPulling = ref(false)
+  const isRefreshing = ref(false)
+
+  const pullProgress = computed(() => Math.min(pullDistance.value / PULL_THRESHOLD, 1))
+
+  let startY = 0
+  let tracking = false
+
+  function onTouchStart(event: TouchEvent) {
+    if (isRefreshing.value || window.scrollY > 0 || !event.touches[0]) {
+      return
+    }
+
+    startY = event.touches[0].clientY
+    tracking = true
+  }
+
+  function onTouchMove(event: TouchEvent) {
+    if (!tracking || isRefreshing.value || !event.touches[0]) {
+      return
+    }
+
+    const delta = event.touches[0].clientY - startY
+
+    if (delta <= 0) {
+      isPulling.value = false
+      pullDistance.value = 0
+      return
+    }
+
+    if (window.scrollY > 0) {
+      tracking = false
+      isPulling.value = false
+      pullDistance.value = 0
+      return
+    }
+
+    isPulling.value = true
+    pullDistance.value = Math.min(delta * RESISTANCE, MAX_PULL)
+
+    if (event.cancelable) {
+      event.preventDefault()
+    }
+  }
+
+  async function onTouchEnd() {
+    if (!tracking) {
+      return
+    }
+
+    tracking = false
+    isPulling.value = false
+
+    if (pullDistance.value >= PULL_THRESHOLD) {
+      isRefreshing.value = true
+      pullDistance.value = PULL_THRESHOLD
+
+      try {
+        await onRefresh()
+      }
+      finally {
+        isRefreshing.value = false
+        pullDistance.value = 0
+      }
+    }
+    else {
+      pullDistance.value = 0
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener('touchstart', onTouchStart, { passive: true })
+    window.addEventListener('touchmove', onTouchMove, { passive: false })
+    window.addEventListener('touchend', onTouchEnd, { passive: true })
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('touchstart', onTouchStart)
+    window.removeEventListener('touchmove', onTouchMove)
+    window.removeEventListener('touchend', onTouchEnd)
+  })
+
+  return { pullDistance, isPulling, isRefreshing, pullProgress }
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -10,12 +10,16 @@ useHead({
   <div class="flex flex-col min-h-screen">
     <AppHeader />
 
-    <main class="flex-1 w-full flex flex-col pt-4 pb-8">
-      <UContainer class="flex-1 w-full flex flex-col">
-        <AppOriginInfo />
-        <slot />
-      </UContainer>
+    <main class="flex-1 w-full flex flex-col pt-4 pb-20 md:pb-8">
+      <AppPullToRefresh>
+        <UContainer class="flex-1 w-full flex flex-col">
+          <AppOriginInfo />
+          <slot />
+        </UContainer>
+      </AppPullToRefresh>
     </main>
-    <AppFooter />
+    <AppFooter class="hidden md:block" />
+    <AppPwaInstallPrompt />
+    <AppBottomNav />
   </div>
 </template>

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -100,5 +100,10 @@
   "noData": "Keine Daten verfügbar",
   "toWomen": "Zu den Damen",
   "toMen": "Zu den Herren",
-  "leaguesLoaded": "{loaded} / {total} Ligen geladen ({percent}%)"
+  "leaguesLoaded": "{loaded} / {total} Ligen geladen ({percent}%)",
+  "startPage": "Start",
+  "installAppTitle": "App installieren",
+  "installAppDescription": "Für schnelleren Zugriff zum Startbildschirm hinzufügen.",
+  "install": "Installieren",
+  "noLeague": "Ohne Liga"
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -100,5 +100,10 @@
   "noData": "No data available",
   "toWomen": "To women's",
   "toMen": "To men's",
-  "leaguesLoaded": "{loaded} / {total} leagues loaded ({percent}%)"
+  "leaguesLoaded": "{loaded} / {total} leagues loaded ({percent}%)",
+  "startPage": "Home",
+  "installAppTitle": "Install app",
+  "installAppDescription": "Add to your home screen for quicker access.",
+  "install": "Install",
+  "noLeague": "No league"
 }


### PR DESCRIPTION
## Summary

Follow-up to #288 — five mobile-first UX improvements, since the smartphone is this app's primary platform:

- **`AppBottomNav`**: a fixed bottom tab bar (Home / Vereinssuche / Ligasuche / Favoriten) shown on mobile, so primary navigation is thumb-reachable instead of relying solely on the header's hamburger menu.
- **`AppPwaInstallPrompt`**: surfaces the app's existing (but previously invisible) `@vite-pwa/nuxt` install prompt via `$pwa.showInstallPrompt`, using `UAlert` with install/dismiss actions.
- **Instant, debounced search** (400ms via `@vueuse/core`'s `watchDebounced`) for club and tournament search, instead of requiring an explicit submit or Enter press - faster on mobile.
- **Teams grouped by league** in the club team list (using the `team.league` field added in #288), so same-named teams (`... II`, `... III`) in different leagues are distinguishable at a glance; the desktop table sorts by league too.
- **`usePullToRefresh`** composable + `AppPullToRefresh` wrapper: native-app-style pull-to-refresh via touch events, calling Nuxt's `refreshNuxtData()` so it refreshes whichever page you're on without any per-page wiring.

## Test plan

- [x] `pnpm lint` - clean
- [x] `pnpm test:run` - 5/5 files, 22/22 tests passing
- [x] `pnpm build` - production build + prerender succeeds
- [ ] Manual touch-gesture testing on a real device (not possible from this sandbox - no touchscreen/browser here)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HuhUfGqi8nC7ESQBsHFBin

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuhUfGqi8nC7ESQBsHFBin)_