### PR TITLE
CI: add lint and build steps (dependency audit follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Lint
+        run: pnpm lint
+
       - name: Run tests
         run: pnpm test
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary
- Audited dependencies for safe updates. All `^`-ranged packages are already at the latest version their range allows.
- The only outdated packages are the exactly-pinned `nuxt`/`@nuxt/kit` (4.4.x → 4.5.2) and `@nuxt/ui` (4.7.1 → 4.11.0). Testing showed `nuxt`/`@nuxt/kit` 4.5.2 breaks the production build (Rollup fails to resolve an SSR styles chunk during prerendering), even though lint and all 22 unit tests still pass. `@nuxt/ui` alone was not the cause. Since this isn't a risk-free update, no dependency version bumps are included in this PR.
- While investigating, found that CI (`pnpm test` only) would not have caught this regression, since the production build isn't exercised. Added `pnpm lint` and `pnpm build` steps to CI so future dependency updates (including Renovate PRs) are validated against the real production build, not just unit tests.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (22/22)
- [x] `pnpm build` succeeds with the new CI steps locally


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7EV1Trrrn8epftB5JPu2k)_