### PR TITLE
Enable Renovate automerge for non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,19 @@
 {
   "extends": [
     "github>nuxt/renovate-config-nuxt"
-  ]
+  ],
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["nuxt", "@nuxt/kit", "@nuxt/schema", "@nuxt/ui"],
+      "automerge": false
+    }
+  ],
+  "lockFileMaintenance": {
+    "automerge": true
+  }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #290 (already merged), which added the `pnpm lint`/`pnpm build` CI steps. This PR builds on that by enabling Renovate automerge now that CI actually validates the production build.
- Patch/minor/pin/digest updates automerge once CI (lint, test, build) passes.
- The Nuxt framework packages (`nuxt`, `@nuxt/kit`, `@nuxt/schema`, `@nuxt/ui`) are excluded from automerge: while auditing dependencies I found that even a minor `nuxt` bump (4.4 → 4.5) silently breaks the production build (a Rollup/SSR-styles regression during prerendering, present in both 4.5.1 and 4.5.2) while unit tests still pass. Those packages still need a human to review the CI result before merging.
- Also checked GitHub's Dependabot-reported vulnerabilities (via `pnpm audit`, since I don't have direct Security-tab API access): most of the outstanding `nuxt` CVEs are only patched in `nuxt@4.5.1+`, which currently can't be adopted due to the build regression above. The most severe ones (RCE / cross-user SSR cache leak) are tied to Nuxt Server Islands, which this project does not use, so real-world exposure is low until upstream fixes the regression.

## Test plan
- [x] `renovate.json` validated with `renovate-config-validator`
- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (22/22)
- [x] `pnpm build` succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7EV1Trrrn8epftB5JPu2k)_